### PR TITLE
Fix for wider characters in alphabet nav

### DIFF
--- a/components/Gallery/src/index.tsx
+++ b/components/Gallery/src/index.tsx
@@ -113,7 +113,8 @@ export const GalleryItem = ({
         grid-template-columns: initial;
         align-items: flex-start;
 
-        @media (min-width: 768px) {
+        @media (
+: 768px) {
           grid-template-columns: 1fr 2fr;
         }
       `}
@@ -190,7 +191,7 @@ export const Character = styled.div`
   align-items: center;
   justify-content: center;
   text-align: center;
-  min-width: 1rem;
+  width: 1rem;
   padding: 4px;
   line-height: 1.4rem;
   height: 1.4rem;

--- a/components/Gallery/src/index.tsx
+++ b/components/Gallery/src/index.tsx
@@ -113,8 +113,7 @@ export const GalleryItem = ({
         grid-template-columns: initial;
         align-items: flex-start;
 
-        @media (
-: 768px) {
+        @media (min-width: 768px) {
           grid-template-columns: 1fr 2fr;
         }
       `}


### PR DESCRIPTION
# What Changed

Prevent shifting of characters on hover in the alphabet navigation.

## Why

We need to set the width of characters, vs min-width to avoid shifting when hovering over wider characters like 'M'.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
