### PR TITLE
Adding `align` prop

### DIFF
--- a/components/Row/src/index.tsx
+++ b/components/Row/src/index.tsx
@@ -7,21 +7,28 @@ export interface RowProps extends Element<"div"> {
   gap?: number;
   /** A specific type of row */
   type?: "large-text";
+  /** Vertical alignment */
+  align?: string;
 }
 
-/** Render a story in an iframe so it's responsive */
-export const Row = ({ gap = 40, type, className, ...props }: RowProps) => (
+/** Render a story in an iframe so it"s responsive */
+export const Row = ({
+  gap = 40,
+  align = "self-start",
+  type,
+  className,
+  ...props
+}: RowProps) => (
   <div
     {...props}
     className={cx(
       className,
       css`
+        align-items: ${align};
         display: grid;
         grid-auto-flow: row;
-        align-items: center;
-        margin: 45px 0;
         grid-gap: ${gap}px;
-        align-items: flex-start;
+        margin: 45px 0;
 
         > * {
           margin: 0 !important;


### PR DESCRIPTION
# What Changed

Adding support for vertical alignment of content in the row.

## Why

Users may want to vertically align their content differently than flex-start.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.4-canary.12.319.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @doc-blocks/accessibility@0.8.4-canary.12.319.0
  npm install @doc-blocks/bundle-size@0.8.4-canary.12.319.0
  npm install @doc-blocks/design-spec@0.8.4-canary.12.319.0
  npm install @doc-blocks/gallery@0.8.4-canary.12.319.0
  npm install @doc-blocks/guideline@0.8.4-canary.12.319.0
  npm install @doc-blocks/intended-usage@0.8.4-canary.12.319.0
  npm install @doc-blocks/related-components@0.8.4-canary.12.319.0
  npm install @doc-blocks/responsive-story@0.8.4-canary.12.319.0
  npm install @doc-blocks/row@0.8.4-canary.12.319.0
  npm install @doc-blocks/shield@0.8.4-canary.12.319.0
  npm install @doc-blocks/shield-row@0.8.4-canary.12.319.0
  npm install @doc-blocks/version@0.8.4-canary.12.319.0
  npm install doc-blocks@0.8.4-canary.12.319.0
  # or 
  yarn add @doc-blocks/accessibility@0.8.4-canary.12.319.0
  yarn add @doc-blocks/bundle-size@0.8.4-canary.12.319.0
  yarn add @doc-blocks/design-spec@0.8.4-canary.12.319.0
  yarn add @doc-blocks/gallery@0.8.4-canary.12.319.0
  yarn add @doc-blocks/guideline@0.8.4-canary.12.319.0
  yarn add @doc-blocks/intended-usage@0.8.4-canary.12.319.0
  yarn add @doc-blocks/related-components@0.8.4-canary.12.319.0
  yarn add @doc-blocks/responsive-story@0.8.4-canary.12.319.0
  yarn add @doc-blocks/row@0.8.4-canary.12.319.0
  yarn add @doc-blocks/shield@0.8.4-canary.12.319.0
  yarn add @doc-blocks/shield-row@0.8.4-canary.12.319.0
  yarn add @doc-blocks/version@0.8.4-canary.12.319.0
  yarn add doc-blocks@0.8.4-canary.12.319.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
