### PR TITLE
Updating exports to include tabs and accordion

### DIFF
--- a/components/Accordion/src/index.tsx
+++ b/components/Accordion/src/index.tsx
@@ -37,7 +37,7 @@ const AccordionContext = React.createContext<AccordionContextProps>({
 });
 
 /** Accordion component */
-const Accordion = ({ children, onChange }: AccordionProps) => {
+export const Accordion = ({ children, onChange }: AccordionProps) => {
   const [selectedId, setSelectedId] = React.useState<string | null>(null);
 
   return (
@@ -139,5 +139,3 @@ const Panel = ({
 
 Accordion.Title = Title;
 Accordion.Panel = Panel;
-
-export default Accordion;

--- a/packages/doc-blocks/package.json
+++ b/packages/doc-blocks/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@doc-blocks/accessibility": "link:../../components/Accessibility",
+    "@doc-blocks/accordion": "link:../../components/Accordion",
     "@doc-blocks/bundle-size": "link:../../components/BundleSize",
     "@doc-blocks/design-spec": "link:../../components/DesignSpec",
     "@doc-blocks/gallery": "link:../../components/Gallery",
@@ -43,6 +44,7 @@
     "@doc-blocks/row": "link:../../components/Row",
     "@doc-blocks/shield": "link:../../components/Shield",
     "@doc-blocks/shield-row": "link:../../components/ShieldRow",
+    "@doc-blocks/tabs": "link:../../components/Tabs",
     "@doc-blocks/version": "link:../../components/Version"
   }
 }

--- a/packages/doc-blocks/src/index.tsx
+++ b/packages/doc-blocks/src/index.tsx
@@ -1,4 +1,5 @@
 export * from "@doc-blocks/accessibility";
+export * from "@doc-blocks/accordion";
 export * from "@doc-blocks/bundle-size";
 export * from "@doc-blocks/design-spec";
 export * from "@doc-blocks/guideline";
@@ -9,4 +10,5 @@ export * from "@doc-blocks/responsive-story";
 export * from "@doc-blocks/row";
 export * from "@doc-blocks/shield";
 export * from "@doc-blocks/shield-row";
+export * from "@doc-blocks/tabs";
 export * from "@doc-blocks/version";


### PR DESCRIPTION
# What Changed

## Why

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.7-canary.16.462.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @doc-blocks/accessibility@0.8.7-canary.16.462.0
  npm install @doc-blocks/accordion@0.8.7-canary.16.462.0
  npm install @doc-blocks/bundle-size@0.8.7-canary.16.462.0
  npm install @doc-blocks/design-spec@0.8.7-canary.16.462.0
  npm install @doc-blocks/gallery@0.8.7-canary.16.462.0
  npm install @doc-blocks/guideline@0.8.7-canary.16.462.0
  npm install @doc-blocks/intended-usage@0.8.7-canary.16.462.0
  npm install @doc-blocks/related-components@0.8.7-canary.16.462.0
  npm install @doc-blocks/responsive-story@0.8.7-canary.16.462.0
  npm install @doc-blocks/row@0.8.7-canary.16.462.0
  npm install @doc-blocks/shield@0.8.7-canary.16.462.0
  npm install @doc-blocks/shield-row@0.8.7-canary.16.462.0
  npm install @doc-blocks/tabs@0.8.7-canary.16.462.0
  npm install @doc-blocks/version@0.8.7-canary.16.462.0
  npm install doc-blocks@0.8.7-canary.16.462.0
  # or 
  yarn add @doc-blocks/accessibility@0.8.7-canary.16.462.0
  yarn add @doc-blocks/accordion@0.8.7-canary.16.462.0
  yarn add @doc-blocks/bundle-size@0.8.7-canary.16.462.0
  yarn add @doc-blocks/design-spec@0.8.7-canary.16.462.0
  yarn add @doc-blocks/gallery@0.8.7-canary.16.462.0
  yarn add @doc-blocks/guideline@0.8.7-canary.16.462.0
  yarn add @doc-blocks/intended-usage@0.8.7-canary.16.462.0
  yarn add @doc-blocks/related-components@0.8.7-canary.16.462.0
  yarn add @doc-blocks/responsive-story@0.8.7-canary.16.462.0
  yarn add @doc-blocks/row@0.8.7-canary.16.462.0
  yarn add @doc-blocks/shield@0.8.7-canary.16.462.0
  yarn add @doc-blocks/shield-row@0.8.7-canary.16.462.0
  yarn add @doc-blocks/tabs@0.8.7-canary.16.462.0
  yarn add @doc-blocks/version@0.8.7-canary.16.462.0
  yarn add doc-blocks@0.8.7-canary.16.462.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
