### PR TITLE
Adding className support for accordion

### DIFF
--- a/components/Accordion/src/index.tsx
+++ b/components/Accordion/src/index.tsx
@@ -7,15 +7,17 @@ interface AccordionCompositionProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
-  /** ID to assign to accordion item */
-  id: string;
   /** Class to apply when selected */
   activeClassName?: string;
+  /** ID to assign to accordion item */
+  id: string;
 }
 
 interface AccordionProps {
   /** Children of accordion wrapper */
   children: React.ReactChild[];
+  /** Classes to apply to accordion wrapper **/
+  className?: string;
   /** Callback after an accordion panel is expanded */
   onChange?: (selectedId: string | null) => void;
 }
@@ -37,12 +39,17 @@ const AccordionContext = React.createContext<AccordionContextProps>({
 });
 
 /** Accordion component */
-export const Accordion = ({ children, onChange }: AccordionProps) => {
+export const Accordion = ({
+  className: accordionWrapperClassName,
+  children,
+  onChange,
+}: AccordionProps) => {
   const [selectedId, setSelectedId] = React.useState<string | null>(null);
 
   return (
     <AccordionContext.Provider value={{ selectedId, setSelectedId, onChange }}>
       <div
+        className={accordionWrapperClassName}
         css={css`
           position: relative;
           margin: 14px 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,34 +1730,34 @@
   integrity sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==
 
 "@doc-blocks/accessibility@link:components/Accessibility":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@doc-blocks/shield" "link:components/Shield"
     emotion "^10.0.27"
 
 "@doc-blocks/accordion@link:components/Accordion":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "7.11.2"
     "@emotion/react" "11.4.1"
 
 "@doc-blocks/bundle-size@link:components/BundleSize":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@doc-blocks/shield" "link:components/Shield"
     emotion "^10.0.27"
 
 "@doc-blocks/design-spec@link:components/DesignSpec":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@doc-blocks/shield" "link:components/Shield"
     emotion "^10.0.27"
 
 "@doc-blocks/gallery@link:components/Gallery":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "7.11.2"
     "@doc-blocks/design-spec" "link:components/DesignSpec"
@@ -1768,7 +1768,7 @@
     use-isomorphic-layout-effect "1.0.0"
 
 "@doc-blocks/guideline@link:components/Guideline":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@design-systems/utils" "2.17.5"
@@ -1776,14 +1776,14 @@
     emotion "^10.0.27"
 
 "@doc-blocks/intended-usage@link:components/IntendedUsage":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@design-systems/utils" "2.17.5"
     emotion "^10.0.27"
 
 "@doc-blocks/related-components@link:components/RelatedComponents":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@emotion/core" "^10.0.28"
@@ -1791,7 +1791,7 @@
     emotion "^10.0.27"
 
 "@doc-blocks/responsive-story@link:components/ResponsiveStory":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@design-systems/utils" "2.17.5"
@@ -1801,34 +1801,34 @@
     emotion "^10.0.27"
 
 "@doc-blocks/row@link:components/Row":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@design-systems/utils" "2.17.5"
     emotion "^10.0.27"
 
 "@doc-blocks/shield-row@link:components/ShieldRow":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@design-systems/utils" "2.17.5"
     emotion "^10.0.27"
 
 "@doc-blocks/shield@link:components/Shield":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     emotion "^10.0.27"
 
 "@doc-blocks/tabs@link:components/Tabs":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "7.11.2"
     "@emotion/react" "11.4.0"
     styled-components "5.3.0"
 
 "@doc-blocks/version@link:components/Version":
-  version "0.8.8"
+  version "0.8.9"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@doc-blocks/shield" "link:components/Shield"
@@ -3459,9 +3459,9 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@royriojas/get-exports-from-file@git+https://github.com/hipstersmoothie/get-exports-from-file.git#all":
+"@royriojas/get-exports-from-file@https://github.com/hipstersmoothie/get-exports-from-file#all":
   version "1.3.0"
-  resolved "git+https://github.com/hipstersmoothie/get-exports-from-file.git#2674835dac0cb1a9821956020d00db22ef9efae0"
+  resolved "https://github.com/hipstersmoothie/get-exports-from-file#2674835dac0cb1a9821956020d00db22ef9efae0"
   dependencies:
     "@babel/parser" "7.4.5"
     "@babel/traverse" "7.4.5"
@@ -8975,9 +8975,9 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-"degit@git+https://github.com/hipstersmoothie/degit.git#private-release":
+"degit@https://github.com/hipstersmoothie/degit.git#private-release":
   version "2.1.4"
-  resolved "git+https://github.com/hipstersmoothie/degit.git#77bdec052337a560e3487b4c45e402d5de49fe55"
+  resolved "https://github.com/hipstersmoothie/degit.git#77bdec052337a560e3487b4c45e402d5de49fe55"
   dependencies:
     chalk "2.4.2"
     githuburl "0.1.6"
@@ -9816,9 +9816,9 @@ eslint-formatter-pretty@^3.0.0:
     string-width "^4.2.0"
     supports-hyperlinks "^2.0.0"
 
-"eslint-import-resolver-lerna@git+https://github.com/hipstersmoothie/eslint-import-resolver-lerna.git#catch":
+"eslint-import-resolver-lerna@https://github.com/hipstersmoothie/eslint-import-resolver-lerna.git#catch":
   version "1.1.0"
-  resolved "git+https://github.com/hipstersmoothie/eslint-import-resolver-lerna.git#5c67ee424b102be38755728b55102e12f1bbd52d"
+  resolved "https://github.com/hipstersmoothie/eslint-import-resolver-lerna.git#5c67ee424b102be38755728b55102e12f1bbd52d"
 
 eslint-import-resolver-node@^0.3.2, eslint-import-resolver-node@^0.3.3:
   version "0.3.6"


### PR DESCRIPTION
# What Changed

Adding support for className to the `accordion` component, similar to how we support that for tabs.

## Why

Users may want to further customize the styles for accordions and providing a class at the wrapper level helps organize styles better.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.10-canary.19.500.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @doc-blocks/accessibility@0.8.10-canary.19.500.0
  npm install @doc-blocks/accordion@0.8.10-canary.19.500.0
  npm install @doc-blocks/bundle-size@0.8.10-canary.19.500.0
  npm install @doc-blocks/design-spec@0.8.10-canary.19.500.0
  npm install @doc-blocks/gallery@0.8.10-canary.19.500.0
  npm install @doc-blocks/guideline@0.8.10-canary.19.500.0
  npm install @doc-blocks/intended-usage@0.8.10-canary.19.500.0
  npm install @doc-blocks/related-components@0.8.10-canary.19.500.0
  npm install @doc-blocks/responsive-story@0.8.10-canary.19.500.0
  npm install @doc-blocks/row@0.8.10-canary.19.500.0
  npm install @doc-blocks/shield@0.8.10-canary.19.500.0
  npm install @doc-blocks/shield-row@0.8.10-canary.19.500.0
  npm install @doc-blocks/tabs@0.8.10-canary.19.500.0
  npm install @doc-blocks/version@0.8.10-canary.19.500.0
  npm install doc-blocks@0.8.10-canary.19.500.0
  # or 
  yarn add @doc-blocks/accessibility@0.8.10-canary.19.500.0
  yarn add @doc-blocks/accordion@0.8.10-canary.19.500.0
  yarn add @doc-blocks/bundle-size@0.8.10-canary.19.500.0
  yarn add @doc-blocks/design-spec@0.8.10-canary.19.500.0
  yarn add @doc-blocks/gallery@0.8.10-canary.19.500.0
  yarn add @doc-blocks/guideline@0.8.10-canary.19.500.0
  yarn add @doc-blocks/intended-usage@0.8.10-canary.19.500.0
  yarn add @doc-blocks/related-components@0.8.10-canary.19.500.0
  yarn add @doc-blocks/responsive-story@0.8.10-canary.19.500.0
  yarn add @doc-blocks/row@0.8.10-canary.19.500.0
  yarn add @doc-blocks/shield@0.8.10-canary.19.500.0
  yarn add @doc-blocks/shield-row@0.8.10-canary.19.500.0
  yarn add @doc-blocks/tabs@0.8.10-canary.19.500.0
  yarn add @doc-blocks/version@0.8.10-canary.19.500.0
  yarn add doc-blocks@0.8.10-canary.19.500.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
