### PR TITLE
Removing width and horizontal padding from accordion panel

### DIFF
--- a/components/Accordion/src/index.tsx
+++ b/components/Accordion/src/index.tsx
@@ -109,10 +109,6 @@ const Panel = ({
         height: auto;
         overflow: hidden;
 
-        ${!isSelected && `padding: 0;`}
-
-        ${isSelected && `padding: 16px 0;`}
-
         @media (prefers-reduced-motion) {
           transition: none;
         }


### PR DESCRIPTION
# What Changed

Removing width and extra padding CSS from accordion because it was making a few assumptions with how users would want to style their accordions. 

## Why

Users may not want to indent content in their panel. Allow them to add that in themselves if desired.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.11-canary.21.533.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @doc-blocks/accessibility@0.8.11-canary.21.533.0
  npm install @doc-blocks/accordion@0.8.11-canary.21.533.0
  npm install @doc-blocks/bundle-size@0.8.11-canary.21.533.0
  npm install @doc-blocks/design-spec@0.8.11-canary.21.533.0
  npm install @doc-blocks/gallery@0.8.11-canary.21.533.0
  npm install @doc-blocks/guideline@0.8.11-canary.21.533.0
  npm install @doc-blocks/intended-usage@0.8.11-canary.21.533.0
  npm install @doc-blocks/related-components@0.8.11-canary.21.533.0
  npm install @doc-blocks/responsive-story@0.8.11-canary.21.533.0
  npm install @doc-blocks/row@0.8.11-canary.21.533.0
  npm install @doc-blocks/shield@0.8.11-canary.21.533.0
  npm install @doc-blocks/shield-row@0.8.11-canary.21.533.0
  npm install @doc-blocks/tabs@0.8.11-canary.21.533.0
  npm install @doc-blocks/version@0.8.11-canary.21.533.0
  npm install doc-blocks@0.8.11-canary.21.533.0
  # or 
  yarn add @doc-blocks/accessibility@0.8.11-canary.21.533.0
  yarn add @doc-blocks/accordion@0.8.11-canary.21.533.0
  yarn add @doc-blocks/bundle-size@0.8.11-canary.21.533.0
  yarn add @doc-blocks/design-spec@0.8.11-canary.21.533.0
  yarn add @doc-blocks/gallery@0.8.11-canary.21.533.0
  yarn add @doc-blocks/guideline@0.8.11-canary.21.533.0
  yarn add @doc-blocks/intended-usage@0.8.11-canary.21.533.0
  yarn add @doc-blocks/related-components@0.8.11-canary.21.533.0
  yarn add @doc-blocks/responsive-story@0.8.11-canary.21.533.0
  yarn add @doc-blocks/row@0.8.11-canary.21.533.0
  yarn add @doc-blocks/shield@0.8.11-canary.21.533.0
  yarn add @doc-blocks/shield-row@0.8.11-canary.21.533.0
  yarn add @doc-blocks/tabs@0.8.11-canary.21.533.0
  yarn add @doc-blocks/version@0.8.11-canary.21.533.0
  yarn add doc-blocks@0.8.11-canary.21.533.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
