### PR TITLE
Adding styled-components dependency to Accordion

### DIFF
--- a/components/Accordion/package.json
+++ b/components/Accordion/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "@babel/runtime": "7.11.2",
-    "@emotion/react": "11.4.1"
+    "@emotion/react": "11.4.1",
+    "styled-components": "5.3.0"
   },
   "peerDependencies": {
     "react": ">= 16.8.6"


### PR DESCRIPTION
# What Changed

Adding `styled-components` as a module dependency so it gets bundled with the package.

## Why

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.12-canary.22.542.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @doc-blocks/accessibility@0.8.12-canary.22.542.0
  npm install @doc-blocks/accordion@0.8.12-canary.22.542.0
  npm install @doc-blocks/bundle-size@0.8.12-canary.22.542.0
  npm install @doc-blocks/design-spec@0.8.12-canary.22.542.0
  npm install @doc-blocks/gallery@0.8.12-canary.22.542.0
  npm install @doc-blocks/guideline@0.8.12-canary.22.542.0
  npm install @doc-blocks/intended-usage@0.8.12-canary.22.542.0
  npm install @doc-blocks/related-components@0.8.12-canary.22.542.0
  npm install @doc-blocks/responsive-story@0.8.12-canary.22.542.0
  npm install @doc-blocks/row@0.8.12-canary.22.542.0
  npm install @doc-blocks/shield@0.8.12-canary.22.542.0
  npm install @doc-blocks/shield-row@0.8.12-canary.22.542.0
  npm install @doc-blocks/tabs@0.8.12-canary.22.542.0
  npm install @doc-blocks/version@0.8.12-canary.22.542.0
  npm install doc-blocks@0.8.12-canary.22.542.0
  # or 
  yarn add @doc-blocks/accessibility@0.8.12-canary.22.542.0
  yarn add @doc-blocks/accordion@0.8.12-canary.22.542.0
  yarn add @doc-blocks/bundle-size@0.8.12-canary.22.542.0
  yarn add @doc-blocks/design-spec@0.8.12-canary.22.542.0
  yarn add @doc-blocks/gallery@0.8.12-canary.22.542.0
  yarn add @doc-blocks/guideline@0.8.12-canary.22.542.0
  yarn add @doc-blocks/intended-usage@0.8.12-canary.22.542.0
  yarn add @doc-blocks/related-components@0.8.12-canary.22.542.0
  yarn add @doc-blocks/responsive-story@0.8.12-canary.22.542.0
  yarn add @doc-blocks/row@0.8.12-canary.22.542.0
  yarn add @doc-blocks/shield@0.8.12-canary.22.542.0
  yarn add @doc-blocks/shield-row@0.8.12-canary.22.542.0
  yarn add @doc-blocks/tabs@0.8.12-canary.22.542.0
  yarn add @doc-blocks/version@0.8.12-canary.22.542.0
  yarn add doc-blocks@0.8.12-canary.22.542.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
