### PR TITLE
add missing peer deps

### DIFF
--- a/components/Accordion/package.json
+++ b/components/Accordion/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/runtime": "7.11.2",
     "@emotion/react": "11.4.1",
+    "react-is": "^16.8.1",
     "styled-components": "5.3.0"
   },
   "peerDependencies": {

--- a/components/Guideline/package.json
+++ b/components/Guideline/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@design-systems/utils": "2.17.5",
+    "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "emotion": "^10.0.27"
   },

--- a/components/RelatedComponents/package.json
+++ b/components/RelatedComponents/package.json
@@ -34,8 +34,8 @@
     "emotion": "^10.0.27"
   },
   "peerDependencies": {
-    "@storybook/addon-links": "6.2.9",
-    "@storybook/components": "6.2.9",
+    "@storybook/addon-links": ">= 6.2.9",
+    "@storybook/components": ">= 6.2.9",
     "react": ">= 16.8.6"
   },
   "devDependencies": {

--- a/components/ResponsiveStory/package.json
+++ b/components/ResponsiveStory/package.json
@@ -36,7 +36,7 @@
     "emotion": "^10.0.27"
   },
   "peerDependencies": {
-    "@storybook/addon-docs": "6.2.9",
+    "@storybook/addon-docs": ">= 6.2.9",
     "react": ">= 16.8.6"
   },
   "devDependencies": {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.14-canary.25.569.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @doc-blocks/accessibility@0.8.14-canary.25.569.0
  npm install @doc-blocks/accordion@0.8.14-canary.25.569.0
  npm install @doc-blocks/bundle-size@0.8.14-canary.25.569.0
  npm install @doc-blocks/design-spec@0.8.14-canary.25.569.0
  npm install @doc-blocks/gallery@0.8.14-canary.25.569.0
  npm install @doc-blocks/guideline@0.8.14-canary.25.569.0
  npm install @doc-blocks/intended-usage@0.8.14-canary.25.569.0
  npm install @doc-blocks/related-components@0.8.14-canary.25.569.0
  npm install @doc-blocks/responsive-story@0.8.14-canary.25.569.0
  npm install @doc-blocks/row@0.8.14-canary.25.569.0
  npm install @doc-blocks/shield@0.8.14-canary.25.569.0
  npm install @doc-blocks/shield-row@0.8.14-canary.25.569.0
  npm install @doc-blocks/tabs@0.8.14-canary.25.569.0
  npm install @doc-blocks/version@0.8.14-canary.25.569.0
  npm install doc-blocks@0.8.14-canary.25.569.0
  # or 
  yarn add @doc-blocks/accessibility@0.8.14-canary.25.569.0
  yarn add @doc-blocks/accordion@0.8.14-canary.25.569.0
  yarn add @doc-blocks/bundle-size@0.8.14-canary.25.569.0
  yarn add @doc-blocks/design-spec@0.8.14-canary.25.569.0
  yarn add @doc-blocks/gallery@0.8.14-canary.25.569.0
  yarn add @doc-blocks/guideline@0.8.14-canary.25.569.0
  yarn add @doc-blocks/intended-usage@0.8.14-canary.25.569.0
  yarn add @doc-blocks/related-components@0.8.14-canary.25.569.0
  yarn add @doc-blocks/responsive-story@0.8.14-canary.25.569.0
  yarn add @doc-blocks/row@0.8.14-canary.25.569.0
  yarn add @doc-blocks/shield@0.8.14-canary.25.569.0
  yarn add @doc-blocks/shield-row@0.8.14-canary.25.569.0
  yarn add @doc-blocks/tabs@0.8.14-canary.25.569.0
  yarn add @doc-blocks/version@0.8.14-canary.25.569.0
  yarn add doc-blocks@0.8.14-canary.25.569.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
