### PR TITLE
fix: publish on master push

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,9 @@ on:
     types: [opened, synchronize, reopened]
   release:
     types: [created]
+  push:
+    branches:
+      - "master"
 
 jobs:
   build-publish:


### PR DESCRIPTION
# What Changed

- Run release pipeline on master push

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.16--canary.35.14768876241.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @doc-blocks/accessibility@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/accordion@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/bundle-size@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/design-spec@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/guideline@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/intended-usage@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/related-components@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/responsive-story@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/row@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/shield@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/shield-row@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/tabs@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/version@0.8.16--canary.35.14768876241.0
  npm install @doc-blocks/doc-blocks@0.8.16--canary.35.14768876241.0
  # or 
  yarn add @doc-blocks/accessibility@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/accordion@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/bundle-size@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/design-spec@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/guideline@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/intended-usage@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/related-components@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/responsive-story@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/row@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/shield@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/shield-row@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/tabs@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/version@0.8.16--canary.35.14768876241.0
  yarn add @doc-blocks/doc-blocks@0.8.16--canary.35.14768876241.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
